### PR TITLE
Wrap esjc subscription dropped exceptions and provide drop reason

### DIFF
--- a/k-es-esjc/src/main/kotlin/no/ks/kes/esjc/EsjcSubscriptionDroppedException.kt
+++ b/k-es-esjc/src/main/kotlin/no/ks/kes/esjc/EsjcSubscriptionDroppedException.kt
@@ -1,0 +1,8 @@
+package no.ks.kes.esjc
+
+import com.github.msemys.esjc.SubscriptionDropReason
+
+/**
+ * Exception thrown when subscription is dropped
+ */
+class EsjcSubscriptionDroppedException(val reason: SubscriptionDropReason, cause: Exception) : RuntimeException("Subscription was dropped. Reason: $reason", cause)

--- a/k-es-esjc/src/test/kotlin/no/ks/kes/esjc/EsjcEventSubscriberTest.kt
+++ b/k-es-esjc/src/test/kotlin/no/ks/kes/esjc/EsjcEventSubscriberTest.kt
@@ -8,10 +8,7 @@ import io.kotest.data.row
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.beInstanceOf
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.slot
-import io.mockk.verify
+import io.mockk.*
 import java.util.*
 
 internal class EsjcEventSubscriberTest : StringSpec() {
@@ -56,6 +53,7 @@ internal class EsjcEventSubscriberTest : StringSpec() {
                 cause should beInstanceOf<ConnectionClosedException>()
             }
             verify(exactly = 1) { eventStoreMock.subscribeToStreamFrom("\$ce-$category", eq(eventnumber), any(), ofType<CatchUpSubscriptionListener>()) }
+            confirmVerified(subscription)
 
         }
 


### PR DESCRIPTION
- wrap subscription dropped in EsjcSubscriptionDroppedException﻿
