### PR TITLE
Add onclose to saga subscription

### DIFF
--- a/k-es-demo-app/docker-compose.yml
+++ b/k-es-demo-app/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - 1433:1433
 
   eventstore:
-    image: eventstore/eventstore
+    image: eventstore/eventstore:release-5.0.8
     environment:
       - EVENTSTORE_RUN_PROJECTIONS=All
       - EVENTSTORE_START_STANDARD_PROJECTIONS=True

--- a/k-es-lib/src/main/kotlin/no/ks/kes/lib/Sagas.kt
+++ b/k-es-lib/src/main/kotlin/no/ks/kes/lib/Sagas.kt
@@ -73,7 +73,7 @@ object Sagas {
     }
 
     private val defaultOnCloseHandler = { exception: Exception ->
-        log.error(exception) { "Event subscription was closed. Shutting down." }
+        log.error(exception) { "Event subscription for Sagas was closed. Shutting down." }
         exitProcess(1)
     }
 }


### PR DESCRIPTION
- add the ability to specify an onClose handler for Saga subscription as well with a default handler that logs the specified exception and exits the process
- test using the latest eventstore version (5.0.8)