### PR TITLE
Allows getting hwm value without running init

### DIFF
--- a/k-es-lib/src/main/kotlin/no/ks/kes/lib/HwmTrackerRepository.kt
+++ b/k-es-lib/src/main/kotlin/no/ks/kes/lib/HwmTrackerRepository.kt
@@ -1,6 +1,7 @@
 package no.ks.kes.lib
 
 interface HwmTrackerRepository {
+    fun current(subscriber: String): Long?
     fun getOrInit(subscriber: String): Long
     fun update(subscriber: String, hwm: Long)
 }

--- a/k-es-lib/src/test/kotlin/no/ks/kes/lib/ProjectionsTest.kt
+++ b/k-es-lib/src/test/kotlin/no/ks/kes/lib/ProjectionsTest.kt
@@ -45,6 +45,7 @@ internal class ProjectionsTest : StringSpec() {
                     projections = setOf(startDates),
                     projectionRepository = object : ProjectionRepository {
                         override val hwmTracker = object : HwmTrackerRepository {
+                            override fun current(subscriber: String): Long? = 0L
                             override fun getOrInit(subscriber: String): Long = 0L
                             override fun update(subscriber: String, hwm: Long) {}
                         }


### PR DESCRIPTION
For monitoring purposes, we should have a way of fetching an HWM if it exists