### PR TITLE
Add unsyncronised cmd handler function

### DIFF
--- a/k-es-lib/src/main/kotlin/no/ks/kes/lib/CmdHandler.kt
+++ b/k-es-lib/src/main/kotlin/no/ks/kes/lib/CmdHandler.kt
@@ -33,7 +33,7 @@ abstract class CmdHandler<A : Aggregate>(private val repository: AggregateReposi
     fun handle(cmd: Cmd<A>): A = handleUnsynchronized(cmd)
 
     /**
-     * Handler that is not synchronized
+     * Handler that is not synchronized. To be used in cases where handling multiple commands from several threads simultaneously is safe. Use with care
      */
     fun handleUnsynchronized(cmd: Cmd<A>): A {
         val readResult = readAggregate(cmd)

--- a/k-es-test-support/src/test/kotlin/no/ks/kes/test/example/EngineTest.kt
+++ b/k-es-test-support/src/test/kotlin/no/ks/kes/test/example/EngineTest.kt
@@ -85,7 +85,7 @@ class EngineTest : StringSpec({
                     events shouldHaveAtLeastSize 2
                     events.filterIsInstance<Events.Created>() shouldHaveSize 1
                     // At this point we really don't know how many of these events was applied as EngineCmdHandler checks aggregate state before generating Started events
-                    // As we are using the handleUnsynchronized function we can therefore not gurantee how many started events are generated
+                    // As we are using the handleUnsynchronized function we can therefore not guarantee how many started events are generated
                     events.filterIsInstance<Events.Started>() shouldHaveAtLeastSize 1
                 } ?: fail("No events was found for aggregate")
             }

--- a/k-es-test-support/src/test/kotlin/no/ks/kes/test/example/EngineTest.kt
+++ b/k-es-test-support/src/test/kotlin/no/ks/kes/test/example/EngineTest.kt
@@ -8,6 +8,7 @@ import io.kotest.assertions.timing.eventually
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldHaveAtLeastSize
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
@@ -15,11 +16,15 @@ import io.kotest.matchers.throwable.shouldHaveMessage
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.uuid
 import io.kotest.property.checkAll
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import no.ks.kes.lib.Projections
 import no.ks.kes.lib.Sagas
 import no.ks.kes.test.AggregateKey
 import no.ks.kes.test.withKes
 import java.util.*
+import java.util.concurrent.Executors
 import kotlin.time.ExperimentalTime
 import kotlin.time.seconds
 
@@ -39,6 +44,48 @@ class EngineTest : StringSpec({
                 kes.eventStream.get(AggregateKey(ENGINE_AGGREGATE_TYPE, aggregateId))?.asClue { events ->
                     events shouldHaveSize 1
                     events.filterIsInstance<Events.Created>() shouldHaveSize 1
+                } ?: fail("No events was found for aggregate")
+            }
+        }
+    }
+
+    "Test command handler using several threads" {
+        withKes(eventSerdes = Events.serdes, cmdSerdes = Cmds.serdes) { kes ->
+            val engineCmdHandler = EngineCmdHandler(kes.aggregateRepository)
+            val aggregateId = UUID.randomUUID()
+            engineCmdHandler.handle(Cmds.Create(aggregateId)).asClue {
+                it.id shouldBe aggregateId
+                it.running shouldBe false
+                it.startCount shouldBe 0
+            }
+            eventually(3.seconds) {
+                kes.eventStream.get(AggregateKey(ENGINE_AGGREGATE_TYPE, aggregateId))?.asClue { events ->
+                    events shouldHaveSize 1
+                    events.filterIsInstance<Events.Created>() shouldHaveSize 1
+                } ?: fail("No events was found for aggregate")
+            }
+
+            Executors.newFixedThreadPool(10).asCoroutineDispatcher().use { dispatcher ->
+                awaitAll(
+                        async(dispatcher) { engineCmdHandler.handleUnsynchronized(Cmds.Start(aggregateId)) },
+                        async(dispatcher) { engineCmdHandler.handleUnsynchronized(Cmds.Start(aggregateId)) },
+                        async(dispatcher) { engineCmdHandler.handleUnsynchronized(Cmds.Start(aggregateId)) },
+                        async(dispatcher) { engineCmdHandler.handleUnsynchronized(Cmds.Start(aggregateId)) },
+                        async(dispatcher) { engineCmdHandler.handleUnsynchronized(Cmds.Start(aggregateId)) },
+                        async(dispatcher) { engineCmdHandler.handleUnsynchronized(Cmds.Start(aggregateId)) },
+                        async(dispatcher) { engineCmdHandler.handleUnsynchronized(Cmds.Start(aggregateId)) },
+                        async(dispatcher) { engineCmdHandler.handleUnsynchronized(Cmds.Start(aggregateId)) },
+                        async(dispatcher) { engineCmdHandler.handleUnsynchronized(Cmds.Start(aggregateId)) },
+                        async(dispatcher) { engineCmdHandler.handleUnsynchronized(Cmds.Start(aggregateId)) }
+                )
+
+            }
+            eventually(3.seconds) {
+                kes.eventStream.get(AggregateKey(ENGINE_AGGREGATE_TYPE, aggregateId))?.asClue { events ->
+                    events shouldHaveAtLeastSize 2
+                    events.filterIsInstance<Events.Created>() shouldHaveSize 1
+                    // At this point we really don't know how many of these events was applied as the commands where handled using the handleUnsynchronized function
+                    events.filterIsInstance<Events.Started>() shouldHaveAtLeastSize 1
                 } ?: fail("No events was found for aggregate")
             }
         }

--- a/k-es-test-support/src/test/kotlin/no/ks/kes/test/example/EngineTest.kt
+++ b/k-es-test-support/src/test/kotlin/no/ks/kes/test/example/EngineTest.kt
@@ -84,7 +84,8 @@ class EngineTest : StringSpec({
                 kes.eventStream.get(AggregateKey(ENGINE_AGGREGATE_TYPE, aggregateId))?.asClue { events ->
                     events shouldHaveAtLeastSize 2
                     events.filterIsInstance<Events.Created>() shouldHaveSize 1
-                    // At this point we really don't know how many of these events was applied as the commands where handled using the handleUnsynchronized function
+                    // At this point we really don't know how many of these events was applied as EngineCmdHandler checks aggregate state before generating Started events
+                    // As we are using the handleUnsynchronized function we can therefore not gurantee how many started events are generated
                     events.filterIsInstance<Events.Started>() shouldHaveAtLeastSize 1
                 } ?: fail("No events was found for aggregate")
             }


### PR DESCRIPTION
In some cases an application needs to run multiple cmds against the same aggregate at the same time. For these cases we need a handleUnsychronized function on CmdHandler﻿
