### PR TITLE
Add proto module to bom

### DIFF
--- a/k-es-bom/pom.xml
+++ b/k-es-bom/pom.xml
@@ -42,6 +42,11 @@
             </dependency>
             <dependency>
                 <groupId>no.ks.fiks</groupId>
+                <artifactId>k-es-serdes-proto</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>no.ks.fiks</groupId>
                 <artifactId>k-es-test-support</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
Version 2.0 introduced a new k-es-serdes-proto module. However, it was not added to the k-es-bom