### PR TITLE
Ikke gitt at event inneholder aggregatId. 

### DIFF
--- a/k-es-esjc/src/main/kotlin/no/ks/kes/esjc/EsjcEventSubscriberFactory.kt
+++ b/k-es-esjc/src/main/kotlin/no/ks/kes/esjc/EsjcEventSubscriberFactory.kt
@@ -51,9 +51,11 @@ class EsjcEventSubscriberFactory(
                                     val event = EventUpgrader.upgrade(serdes.deserialize(resolvedEvent.event.data, resolvedEvent.event.eventType))
                                     val aggregateId = UUID.fromString(resolvedEvent.event.eventStreamId.takeLast(36))
                                     onEvent.invoke(EventWrapper(
+                                        Event(
                                             aggregateId = aggregateId,
                                             metadata = eventMeta,
-                                            event = event,
+                                            eventData = event
+                                        ),
                                             eventNumber = resolvedEvent.originalEventNumber(),
                                             serializationId = serdes.getSerializationId(event::class)))
                                             .also {

--- a/k-es-esjc/src/test/kotlin/no/ks/kes/esjc/EsjcEventWriterTest.kt
+++ b/k-es-esjc/src/test/kotlin/no/ks/kes/esjc/EsjcEventWriterTest.kt
@@ -27,7 +27,7 @@ internal class EsjcEventWriterTest : StringSpec() {
             val eventAggregateType = UUID.randomUUID().toString()
 
             val aggregateId = UUID.randomUUID()
-            val event: no.ks.kes.lib.Event =
+            val event: Event<SomeEventData> =
                 Event(aggregateId = aggregateId, eventData = SomeEventData(aggregateId))
 
             val capturedEventData = slot<List<EventData>>()

--- a/k-es-lib/src/main/kotlin/no/ks/kes/lib/AggregateRepository.kt
+++ b/k-es-lib/src/main/kotlin/no/ks/kes/lib/AggregateRepository.kt
@@ -5,7 +5,7 @@ import kotlin.reflect.KClass
 
 
 abstract class AggregateRepository() {
-    abstract fun append(aggregateType: String, aggregateId: UUID, expectedEventNumber: ExpectedEventNumber, eventWrappers: List<Event>)
+    abstract fun append(aggregateType: String, aggregateId: UUID, expectedEventNumber: ExpectedEventNumber, eventWrappers: List<Event<*>>)
     abstract fun getSerializationId(eventDataClass: KClass<EventData<*>>): String
 
     fun <A : Aggregate> read(aggregateId: UUID, aggregateConfiguration: ValidatedAggregateConfiguration<A>): AggregateReadResult =

--- a/k-es-lib/src/main/kotlin/no/ks/kes/lib/Event.kt
+++ b/k-es-lib/src/main/kotlin/no/ks/kes/lib/Event.kt
@@ -2,8 +2,8 @@ package no.ks.kes.lib
 
 import java.util.*
 
-data class Event (
+data class Event<E : EventData<*>> (
         val aggregateId : UUID,
-        val eventData: EventData<out Aggregate>,
+        val eventData: E,
         val metadata: Metadata? = null,
 )

--- a/k-es-lib/src/main/kotlin/no/ks/kes/lib/EventWrapper.kt
+++ b/k-es-lib/src/main/kotlin/no/ks/kes/lib/EventWrapper.kt
@@ -1,11 +1,7 @@
 package no.ks.kes.lib
 
-import java.util.*
-
 data class EventWrapper<T : EventData<*>>(
-        val aggregateId: UUID,
-        val event: T,
-        val metadata: Metadata? = null,
+        val event: Event<T>,
         val eventNumber: Long,
         val serializationId: String
 )

--- a/k-es-lib/src/main/kotlin/no/ks/kes/lib/Projection.kt
+++ b/k-es-lib/src/main/kotlin/no/ks/kes/lib/Projection.kt
@@ -12,8 +12,8 @@ abstract class Projection {
         return
     }
 
-    protected inline fun <reified E : EventData<*>> on(crossinline consumer: (EventWrapper<E>) -> Any?) =
-            onWrapper<E> { consumer.invoke(it) }
+    protected inline fun <reified E : EventData<*>> on(crossinline consumer: (Event<E>) -> Any?) =
+            onWrapper<E> { consumer.invoke(it.event) }
 
     @Suppress("UNCHECKED_CAST")
     protected inline fun <reified E : EventData<*>> onWrapper(crossinline consumer: (EventWrapper<E>) -> Any?) {
@@ -51,7 +51,7 @@ abstract class Projection {
 
             if (projector != null) {
                 projector.invoke(wrapper)
-                log.debug("Event ${wrapper.serializationId} on aggregate ${wrapper.aggregateId} " +
+                log.debug("Event ${wrapper.serializationId} on aggregate ${wrapper.event.aggregateId} " +
                         "applied to projection $name")
             }
 

--- a/k-es-lib/src/main/kotlin/no/ks/kes/lib/Projection.kt
+++ b/k-es-lib/src/main/kotlin/no/ks/kes/lib/Projection.kt
@@ -46,7 +46,6 @@ abstract class Projection {
         }
 
         fun accept(wrapper: EventWrapper<*>) {
-            log.debug { "ACCEPT ${wrapper.serializationId}" }
             val projector = projectors[wrapper.serializationId]
 
             if (projector != null) {

--- a/k-es-lib/src/main/kotlin/no/ks/kes/lib/Projection.kt
+++ b/k-es-lib/src/main/kotlin/no/ks/kes/lib/Projection.kt
@@ -12,8 +12,8 @@ abstract class Projection {
         return
     }
 
-    protected inline fun <reified E : EventData<*>> on(crossinline consumer: (E) -> Any?) =
-            onWrapper<E> { consumer.invoke(it.event) }
+    protected inline fun <reified E : EventData<*>> on(crossinline consumer: (EventWrapper<E>) -> Any?) =
+            onWrapper<E> { consumer.invoke(it) }
 
     @Suppress("UNCHECKED_CAST")
     protected inline fun <reified E : EventData<*>> onWrapper(crossinline consumer: (EventWrapper<E>) -> Any?) {
@@ -46,6 +46,7 @@ abstract class Projection {
         }
 
         fun accept(wrapper: EventWrapper<*>) {
+            log.debug { "ACCEPT ${wrapper.serializationId}" }
             val projector = projectors[wrapper.serializationId]
 
             if (projector != null) {

--- a/k-es-lib/src/test/kotlin/no/ks/kes/lib/AggregateConfigurationTest.kt
+++ b/k-es-lib/src/test/kotlin/no/ks/kes/lib/AggregateConfigurationTest.kt
@@ -27,8 +27,10 @@ internal class AggregateConfigurationTest : StringSpec() {
                     .getConfiguration { it.simpleName!! }
                     .applyEvent(
                             wrapper = EventWrapper(
+                                Event(
                                     aggregateId = UUID.randomUUID(),
-                                    event = SomeInitEventData(),
+                                    eventData = SomeInitEventData()
+                                ),
                                     eventNumber = -1,
                                     serializationId = SomeInitEventData::class.simpleName!!
                             ),
@@ -65,8 +67,10 @@ internal class AggregateConfigurationTest : StringSpec() {
                     .getConfiguration { it.simpleName!! }
                     .applyEvent(
                             wrapper = EventWrapper(
+                                Event(
                                     aggregateId = UUID.randomUUID(),
-                                    event = SomeInitEventData(),
+                                    eventData = SomeInitEventData())
+                                ,
                                     eventNumber = -1,
                                     serializationId = SomeInitEventData::class.simpleName!!
                             ),
@@ -76,8 +80,10 @@ internal class AggregateConfigurationTest : StringSpec() {
                     .getConfiguration { it.simpleName!! }
                     .applyEvent(
                             EventWrapper(
+                                Event(
                                     aggregateId = UUID.randomUUID(),
-                                    event = SomeLaterEventData(),
+                                    eventData = SomeLaterEventData()
+                                ),
                                     eventNumber = -1,
                                     serializationId = SomeLaterEventData::class.simpleName!!
                             ),
@@ -112,10 +118,10 @@ internal class AggregateConfigurationTest : StringSpec() {
 
             val initializedState0 = aggregateConfig
                     .getConfiguration { it.simpleName!! }
-                    .applyEvent(EventWrapper(UUID.randomUUID(),SomeInitEventData(),null, -1, SomeInitEventData::class.simpleName!!), null)
+                    .applyEvent(EventWrapper(Event(UUID.randomUUID(),SomeInitEventData(),null), -1, SomeInitEventData::class.simpleName!!), null)
             initializedState0!!.initializedWith shouldBe "SomeInitEvent"
 
-            val initializedState1 = aggregateConfig.getConfiguration { it.simpleName!! }.applyEvent(EventWrapper(UUID.randomUUID(),SomeOtherInitEventData(),null, -1, SomeOtherInitEventData::class.simpleName!!), null)
+            val initializedState1 = aggregateConfig.getConfiguration { it.simpleName!! }.applyEvent(EventWrapper(Event(UUID.randomUUID(),SomeOtherInitEventData(),null), -1, SomeOtherInitEventData::class.simpleName!!), null)
             initializedState1!!.initializedWith shouldBe "SomeOtherInitEvent"
 
         }
@@ -141,9 +147,9 @@ internal class AggregateConfigurationTest : StringSpec() {
                 }
             }
 
-            val initializedState = aggregateConfig.getConfiguration { it.simpleName!! }.applyEvent(EventWrapper(UUID.randomUUID(),SomeInitEventData(),null, -1, SomeInitEventData::class.simpleName!!), null)
+            val initializedState = aggregateConfig.getConfiguration { it.simpleName!! }.applyEvent(EventWrapper(Event(UUID.randomUUID(),SomeInitEventData(),null), -1, SomeInitEventData::class.simpleName!!), null)
             initializedState!!.stateInitialized shouldBe true
-            val updatedState = aggregateConfig.getConfiguration { it.simpleName!! }.applyEvent(EventWrapper(UUID.randomUUID(),SomeInitEventData(),null, -1, SomeInitEventData::class.simpleName!!), initializedState)
+            val updatedState = aggregateConfig.getConfiguration { it.simpleName!! }.applyEvent(EventWrapper(Event(UUID.randomUUID(),SomeInitEventData(),null), -1, SomeInitEventData::class.simpleName!!), initializedState)
             updatedState!!.stateUpdated shouldBe true
         }
 
@@ -162,7 +168,7 @@ internal class AggregateConfigurationTest : StringSpec() {
                 }
             }
 
-            shouldThrow<IllegalStateException> { aggregateConfig.getConfiguration { it.simpleName!! }.applyEvent(EventWrapper(UUID.randomUUID(),SomeEventData(),null, Random.nextLong(), SomeEventData::class.simpleName!!), null)}
+            shouldThrow<IllegalStateException> { aggregateConfig.getConfiguration { it.simpleName!! }.applyEvent(EventWrapper(Event(UUID.randomUUID(),SomeEventData(),null), Random.nextLong(), SomeEventData::class.simpleName!!), null)}
                     .message shouldContain "aggregate state has not yet been initialized"
 
         }
@@ -190,10 +196,10 @@ internal class AggregateConfigurationTest : StringSpec() {
                 }
             }
 
-            val derivedState0 = aggregateConfig.getConfiguration { it.simpleName!! }.applyEvent(EventWrapper(UUID.randomUUID(),SomeInitEventData(),null, -1, SomeInitEventData::class.simpleName!!), null)
+            val derivedState0 = aggregateConfig.getConfiguration { it.simpleName!! }.applyEvent(EventWrapper(Event(UUID.randomUUID(),SomeInitEventData(),null), -1, SomeInitEventData::class.simpleName!!), null)
             derivedState0!!.initializedWith shouldBe "SomeInitEvent"
 
-            val derivedState1 = aggregateConfig.getConfiguration { it.simpleName!! }.applyEvent(EventWrapper(UUID.randomUUID(),SomeOtherInitEventData(),null, -1, SomeOtherInitEventData::class.simpleName!!), derivedState0)
+            val derivedState1 = aggregateConfig.getConfiguration { it.simpleName!! }.applyEvent(EventWrapper(Event(UUID.randomUUID(),SomeOtherInitEventData(),null), -1, SomeOtherInitEventData::class.simpleName!!), derivedState0)
             derivedState1!!.initializedWith shouldBe "SomeInitEvent"
 
         }

--- a/k-es-lib/src/test/kotlin/no/ks/kes/lib/AsyncCmdHandlerTest.kt
+++ b/k-es-lib/src/test/kotlin/no/ks/kes/lib/AsyncCmdHandlerTest.kt
@@ -34,7 +34,7 @@ internal class AsyncCmdHandlerTest : StringSpec() {
         "Test that a cmd can initialize an aggregate" {
             val someCmd = SomeCmd(UUID.randomUUID())
 
-            val slot = slot<List<Event>>()
+            val slot = slot<List<Event<*>>>()
 
             val repoMock = mockk<AggregateRepository>().apply {
                 every { getSerializationId(any()) } answers { firstArg<KClass<EventData<*>>>().simpleName!! }
@@ -58,7 +58,7 @@ internal class AsyncCmdHandlerTest : StringSpec() {
 
         "Test that a cmd can append a new event to an existing aggregate" {
             val someCmd = SomeCmd(UUID.randomUUID())
-            val slot = slot<List<Event>>()
+            val slot = slot<List<Event<*>>>()
 
             val repoMock = mockk<AggregateRepository>().apply {
                 every { getSerializationId(any()) } answers { firstArg<KClass<EventData<*>>>().simpleName!! }

--- a/k-es-lib/src/test/kotlin/no/ks/kes/lib/ProjectionTest.kt
+++ b/k-es-lib/src/test/kotlin/no/ks/kes/lib/ProjectionTest.kt
@@ -24,7 +24,7 @@ internal class ProjectionTest : StringSpec() {
                 }
 
                 init {
-                    on<Hired> { startDates.put(it.aggregateId, it.startDate) }
+                    on<Hired> { startDates.put(it.aggregateId, it.event.startDate) }
                 }
             }
 

--- a/k-es-lib/src/test/kotlin/no/ks/kes/lib/ProjectionTest.kt
+++ b/k-es-lib/src/test/kotlin/no/ks/kes/lib/ProjectionTest.kt
@@ -24,7 +24,7 @@ internal class ProjectionTest : StringSpec() {
                 }
 
                 init {
-                    on<Hired> { startDates.put(it.aggregateId, it.event.startDate) }
+                    on<Hired> {startDates.put(it.aggregateId, it.eventData.startDate) }
                 }
             }
 
@@ -35,7 +35,7 @@ internal class ProjectionTest : StringSpec() {
                     recruitedBy = UUID.randomUUID())
 
             StartDatesProjection().apply {
-                getConfiguration { it.simpleName!! }.accept(EventWrapper(aggregateId, hiredEvent, null, 0, hiredEvent::class.simpleName!!))
+                getConfiguration { it.simpleName!! }.accept(EventWrapper(Event(aggregateId, hiredEvent, null), 0, hiredEvent::class.simpleName!!))
 
                 getStartDate(hiredEvent.aggregateId) shouldBe LocalDate.now()
             }

--- a/k-es-lib/src/test/kotlin/no/ks/kes/lib/ProjectionsTest.kt
+++ b/k-es-lib/src/test/kotlin/no/ks/kes/lib/ProjectionsTest.kt
@@ -64,7 +64,7 @@ internal class ProjectionsTest : StringSpec() {
             )
 
             //when we invoke the captured handler from the manager with the subscribed event
-            slot.invoke(EventWrapper(aggregateId,hiredEvent,null, 0, hiredEvent::class.simpleName!!))
+            slot.invoke(EventWrapper(Event(aggregateId,hiredEvent,null), 0, hiredEvent::class.simpleName!!))
 
             //the projection should update
             startDates.hasBeenProjected(hiredEvent.aggregateId) shouldBe true

--- a/k-es-lib/src/test/kotlin/no/ks/kes/lib/SagaEventHandlingTest.kt
+++ b/k-es-lib/src/test/kotlin/no/ks/kes/lib/SagaEventHandlingTest.kt
@@ -27,7 +27,7 @@ class SagaEventHandlingTest : StringSpec() {
                     init({ _: SomeEventData, aggregateId: UUID -> aggregateId }) { _: SomeEventData, aggregateId: UUID -> setState(SomeState(aggregateId)) }
                 }
             }.getConfiguration { it.simpleName!! }
-                    .handleEvent(EventWrapper(aggregateId, event,null, -1, event::class.simpleName!!)) { _, _ -> null }
+                    .handleEvent(EventWrapper(Event(aggregateId, event,null), -1, event::class.simpleName!!)) { _, _ -> null }
                     .run {
                         with(this as SagaRepository.Operation.Insert) {
                             correlationId shouldBe event.aggregateId
@@ -47,7 +47,7 @@ class SagaEventHandlingTest : StringSpec() {
                     init({ _: SomeEventData, aggregateId: UUID -> aggregateId }) { _: SomeEventData, aggregateId: UUID -> setState(SomeState(aggregateId)) }
                 }
             }.getConfiguration { it.simpleName!! }
-                    .handleEvent(EventWrapper(aggregateId,event,null, -1, event::class.simpleName!!)) { id, _ -> SomeState(id) }.apply {
+                    .handleEvent(EventWrapper(Event(aggregateId,event,null), -1, event::class.simpleName!!)) { id, _ -> SomeState(id) }.apply {
                         this shouldBe null
                     }
         }
@@ -64,7 +64,7 @@ class SagaEventHandlingTest : StringSpec() {
                     }
                 }
             }.getConfiguration { it.simpleName!! }
-                    .handleEvent(EventWrapper(aggregateId,event,null, -1, event::class.simpleName!!)) { _, _ -> null }.apply {
+                    .handleEvent(EventWrapper(Event(aggregateId,event,null), -1, event::class.simpleName!!)) { _, _ -> null }.apply {
                         with(this as SagaRepository.Operation.Insert) {
                             correlationId shouldBe event.aggregateId
                             serializationId shouldBe sagaSerializationId
@@ -83,7 +83,7 @@ class SagaEventHandlingTest : StringSpec() {
                     apply({ _: SomeEventData, aggregateId: UUID -> aggregateId }) { _: SomeEventData, _: UUID -> setState(state.copy(updated = true)) }
                 }
             }.getConfiguration { it.simpleName!! }
-                    .handleEvent(EventWrapper(aggregateId,event,null, 0, event::class.simpleName!!)) { id, _ -> SomeState(id) }.apply {
+                    .handleEvent(EventWrapper(Event(aggregateId,event,null), 0, event::class.simpleName!!)) { id, _ -> SomeState(id) }.apply {
                         with(this as SagaRepository.Operation.SagaUpdate) {
                             correlationId shouldBe event.aggregateId
                             serializationId shouldBe sagaSerializationId
@@ -102,7 +102,7 @@ class SagaEventHandlingTest : StringSpec() {
                     apply({ _: SomeEventData, aggregateId: UUID -> aggregateId }) { _: SomeEventData, aggregateId: UUID -> dispatch(SomeCmd(aggregateId)) }
                 }
             }.getConfiguration { it.simpleName!! }
-                    .handleEvent(EventWrapper(aggregateId,event,null, 0, event::class.simpleName!!)) { id, _ -> SomeState(id) }.apply {
+                    .handleEvent(EventWrapper(Event(aggregateId,event,null), 0, event::class.simpleName!!)) { id, _ -> SomeState(id) }.apply {
                         with(this as SagaRepository.Operation.SagaUpdate) {
                             correlationId shouldBe event.aggregateId
                             serializationId shouldBe sagaSerializationId
@@ -125,7 +125,7 @@ class SagaEventHandlingTest : StringSpec() {
                     }
                 }
             }.getConfiguration { it.simpleName!! }
-                    .handleEvent(EventWrapper(aggregateId,event,null, 0, event::class.simpleName!!)) { id, _ -> SomeState(id) }
+                    .handleEvent(EventWrapper(Event(aggregateId,event,null), 0, event::class.simpleName!!)) { id, _ -> SomeState(id) }
                     .run {
                         with(this as SagaRepository.Operation.SagaUpdate) {
                             correlationId shouldBe event.aggregateId
@@ -174,7 +174,7 @@ class SagaEventHandlingTest : StringSpec() {
                     apply({ _: SomeEventData, aggregateId: UUID -> aggregateId }) { _: SomeEventData, _: UUID -> setState(state.copy(updated = true)) }
                 }
             }.getConfiguration { it.simpleName!! }
-                    .handleEvent(EventWrapper(aggregateId,event,null, 0, event::class.simpleName!!)) { _, _ -> null }
+                    .handleEvent(EventWrapper(Event(aggregateId,event,null), 0, event::class.simpleName!!)) { _, _ -> null }
                     .run {
                         with(this as SagaRepository.Operation.Insert) {
                             correlationId shouldBe event.aggregateId
@@ -195,7 +195,7 @@ class SagaEventHandlingTest : StringSpec() {
                     apply({ _: SomeEventData, aggregateId: UUID -> aggregateId }) { _: SomeEventData, _: UUID -> setState(state.copy(updated = true)) }
                 }
             }.getConfiguration { it.simpleName!! }
-                    .handleEvent(EventWrapper(aggregateId,event,null, 0, event::class.simpleName!!)) { id, _ -> SomeState(id) }
+                    .handleEvent(EventWrapper(Event(aggregateId,event,null), 0, event::class.simpleName!!)) { id, _ -> SomeState(id) }
                     .run {
                         with(this as SagaRepository.Operation.SagaUpdate) {
                             correlationId shouldBe event.aggregateId


### PR DESCRIPTION
Sender derfor inn hele EventWrapper obj (aggregatId, event og meta).

Tenker vi løfter minor, men ikke master, pga delvis broken bakoverkompabilitet