### PR TITLE
Ignorerer messages uten event

### DIFF
--- a/k-es-grpc/pom.xml
+++ b/k-es-grpc/pom.xml
@@ -44,6 +44,11 @@
             <groupId>com.eventstore</groupId>
             <artifactId>db-client-java</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.reactivex.rxjava3</groupId>
+            <artifactId>rxjava</artifactId>
+        </dependency>
+
 
         <!--test-->
         <dependency>

--- a/k-es-grpc/src/main/kotlin/no/ks/kes/grpc/GrpcEventUtil.kt
+++ b/k-es-grpc/src/main/kotlin/no/ks/kes/grpc/GrpcEventUtil.kt
@@ -21,7 +21,4 @@ object GrpcEventUtil {
         event.eventType.isEmpty() ||
         event.eventType.startsWith("$")
 
-    fun ReadMessage.isIgnorable(): Boolean =
-        event == null || event.isIgnorable()
-
 }

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
         <mssql-jdbc.version>11.2.1.jre11</mssql-jdbc.version>
         <protobuf-java.version>3.21.9</protobuf-java.version>
         <mongodb-driver-version>4.7.2</mongodb-driver-version>
+        <rxjava.version>3.1.5</rxjava.version>
 
         <junit.jupiter.version>5.9.1</junit.jupiter.version>
         <mockk.version>1.13.2</mockk.version>
@@ -140,6 +141,11 @@
                 <groupId>com.eventstore</groupId>
                 <artifactId>db-client-java</artifactId>
                 <version>${db-client-java.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.reactivex.rxjava3</groupId>
+                <artifactId>rxjava</artifactId>
+                <version>${rxjava.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
- Ignorerer ReadMessage som ikke har event. Dette blir tilsvarende slik det ble gjort av klienten tidligere, ref. endring:
![image](https://user-images.githubusercontent.com/13865017/200550670-be7dec5c-7f1a-401f-9e7b-175b8e09c636.png)


- Repository cleanup, inkludert bruk av rxjava til å konsumere events fra publisher ved lesing av events for et aggregat